### PR TITLE
No country selected view and don't hide keyboard on clear search.

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
@@ -118,9 +118,12 @@ fun ClimateTraceScreen() {
                 }
 
                 Spacer(modifier = Modifier.width(1.dp).fillMaxWidth())
-                selectedCountry?.let { country ->
-                    CountryInfoDetailedView(country, countryEmissionInfo, countryAssetEmissions, isLoadingCountryDetails.value)
-                }
+                CountryInfoDetailedView(
+                    country = selectedCountry,
+                    countryEmissionInfo = countryEmissionInfo,
+                    countryAssetEmissionsList = countryAssetEmissions,
+                    isLoading = isLoadingCountryDetails.value
+                )
             }
         } else {
             Box(Modifier.width(250.dp).fillMaxHeight().background(color = Color.LightGray)) {
@@ -131,19 +134,16 @@ fun ClimateTraceScreen() {
 
             Spacer(modifier = Modifier.width(1.dp).fillMaxHeight())
             Box(Modifier.fillMaxHeight()) {
-                selectedCountry?.let { country ->
-                    CountryInfoDetailedView(
-                        country,
-                        countryEmissionInfo,
-                        countryAssetEmissions,
-                        isLoadingCountryDetails.value
-                    )
-                }
+                CountryInfoDetailedView(
+                    country = selectedCountry,
+                    countryEmissionInfo = countryEmissionInfo,
+                    countryAssetEmissionsList = countryAssetEmissions,
+                    isLoading = isLoadingCountryDetails.value
+                )
             }
         }
     }
 }
-
 
 @Composable
 fun CountryListView(
@@ -216,7 +216,6 @@ fun SearchableList(
             ) {
                 IconButton(onClick = {
                     onSearchQueryChange("")
-                    keyboardController?.hide()
                 }) {
                     Icon(
                         imageVector = Icons.Default.Close,
@@ -232,7 +231,11 @@ fun SearchableList(
             } else {
                 LazyColumn {
                     items(filteredCountryList) { country ->
-                        CountryRow(country, selectedCountry, countrySelected)
+                        CountryRow(
+                            country = country,
+                            selectedCountry = selectedCountry,
+                            countrySelected = countrySelected
+                        )
                     }
                 }
             }
@@ -282,51 +285,70 @@ fun CountryRow(
 
 @Composable
 fun CountryInfoDetailedView(
-    country: Country,
+    country: Country?,
     countryEmissionInfo: CountryEmissionsInfo?,
     countryAssetEmissionsList: List<CountryAssetEmissionsInfo>?,
     isLoading: Boolean
 ) {
 
-    if (isLoading) {
+    if (country == null) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .fillMaxHeight()
                 .wrapContentSize(Alignment.Center)
         ) {
-            CircularProgressIndicator()
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .fillMaxHeight()
+                    .wrapContentSize(Alignment.Center),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text("No Country Selected!", style = MaterialTheme.typography.titleLarge)
+            }
         }
     } else {
-        Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .fillMaxSize()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = country.name,
-                style = MaterialTheme.typography.titleLarge,
-                textAlign = TextAlign.Center
-            )
-
-            Spacer(modifier = Modifier.size(16.dp))
-
-            countryEmissionInfo?.let {
-                val co2 = (countryEmissionInfo.emissions.co2 / 1_000_000).toInt()
-                val percentage =
-                    (countryEmissionInfo.emissions.co2 / countryEmissionInfo.worldEmissions.co2).toPercent(
-                        2
-                    )
-                Text("co2 = $co2 Million Tonnes (2022)")
-                Text("rank = ${countryEmissionInfo.rank} ($percentage)")
+        if (isLoading) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .fillMaxHeight()
+                    .wrapContentSize(Alignment.Center)
+            ) {
+                CircularProgressIndicator()
             }
+        } else {
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .fillMaxSize()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = country.name,
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center
+                )
 
-            Spacer(modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.size(16.dp))
 
-            countryAssetEmissionsList?.let {
-                SectorEmissionsPieChart(countryAssetEmissionsList)
+                countryEmissionInfo?.let {
+                    val co2 = (countryEmissionInfo.emissions.co2 / 1_000_000).toInt()
+                    val percentage =
+                        (countryEmissionInfo.emissions.co2 / countryEmissionInfo.worldEmissions.co2).toPercent(
+                            2
+                        )
+                    Text("co2 = $co2 Million Tonnes (2022)")
+                    Text("rank = ${countryEmissionInfo.rank} ($percentage)")
+                }
+
+                Spacer(modifier = Modifier.size(16.dp))
+
+                countryAssetEmissionsList?.let {
+                    SectorEmissionsPieChart(countryAssetEmissionsList)
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
@@ -336,10 +336,7 @@ fun CountryInfoDetailedView(
 
                 countryEmissionInfo?.let {
                     val co2 = (countryEmissionInfo.emissions.co2 / 1_000_000).toInt()
-                    val percentage =
-                        (countryEmissionInfo.emissions.co2 / countryEmissionInfo.worldEmissions.co2).toPercent(
-                            2
-                        )
+                    val percentage = (countryEmissionInfo.emissions.co2 / countryEmissionInfo.worldEmissions.co2).toPercent(2)
                     Text("co2 = $co2 Million Tonnes (2022)")
                     Text("rank = ${countryEmissionInfo.rank} ($percentage)")
                 }


### PR DESCRIPTION
- To address the issue of an odd appearance in the web and desktop versions when initially loading the app, a text view indicating "No country selected" has been implemented.
- The keyboard will remain visible on iOS/Android devices after the search is cleared, instead of being automatically hidden.


https://github.com/joreilly/ClimateTraceKMP/assets/4012000/f01673ee-04fd-441c-bda1-bb39a2a31cc7


https://github.com/joreilly/ClimateTraceKMP/assets/4012000/5d682f96-8bd1-4764-897a-0bed333fccc5



@joreilly please review