### PR TITLE
Null/Empty check with null safety

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/ClimateTraceApi.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/ClimateTraceApi.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -66,9 +67,10 @@ data class EmissionInfo(
 class ClimateTraceApi(
     private val baseUrl: String = "https://api.climatetrace.org/v4",
 )  {
+    @OptIn(ExperimentalSerializationApi::class)
     private val client = HttpClient {
         install(ContentNegotiation) {
-            json(Json { isLenient = true; ignoreUnknownKeys = true })
+            json(Json { isLenient = true; ignoreUnknownKeys = true; explicitNulls = false})
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -112,7 +113,11 @@ fun ClimateTraceScreen() {
             Column(Modifier.fillMaxWidth()) {
 
                 Box(Modifier.height(250.dp).fillMaxWidth().background(color = Color.LightGray)) {
-                    CountryListView(countryList, selectedCountry, isLoadingCountries.value) { country ->
+                    CountryListView(
+                        countryList,
+                        selectedCountry,
+                        isLoadingCountries.value
+                    ) { country ->
                         selectedCountry = country
                     }
                 }
@@ -227,7 +232,7 @@ fun SearchableList(
         },
         content = {
             if (filteredCountryList.isEmpty() && isLoading.not()) {
-                CountryListEmptyState()
+                EmptyState(message = "search differently")
             } else {
                 LazyColumn {
                     items(filteredCountryList) { country ->
@@ -247,16 +252,19 @@ fun SearchableList(
 }
 
 @Composable
-fun CountryListEmptyState() {
+fun EmptyState(
+    title: String? = null,
+    message: String? = null
+) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .fillMaxHeight()
-            .wrapContentSize(Alignment.Center),
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        Text("No Countries Found!", style = MaterialTheme.typography.titleMedium)
-        Text("search differently", style = MaterialTheme.typography.bodyLarge)
+        Text(title ?: "No Countries Found!", style = MaterialTheme.typography.titleMedium)
+        message?.let {
+            Text(message, style = MaterialTheme.typography.bodyLarge)
+        }
     }
 }
 
@@ -290,7 +298,6 @@ fun CountryInfoDetailedView(
     countryAssetEmissionsList: List<CountryAssetEmissionsInfo>?,
     isLoading: Boolean
 ) {
-
     if (country == null) {
         Column(
             modifier = Modifier
@@ -305,9 +312,11 @@ fun CountryInfoDetailedView(
                     .wrapContentSize(Alignment.Center),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text("No Country Selected!", style = MaterialTheme.typography.titleLarge)
+                Text(text = "No Country Selected!", style = MaterialTheme.typography.titleLarge)
             }
         }
+    } else if ((countryEmissionInfo == null || countryAssetEmissionsList.isNullOrEmpty()) && isLoading.not()) {
+        EmptyState(title = "No data found for ${country.name}")
     } else {
         if (isLoading) {
             Column(
@@ -326,25 +335,26 @@ fun CountryInfoDetailedView(
                     .padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text(
-                    text = country.name,
-                    style = MaterialTheme.typography.titleLarge,
-                    textAlign = TextAlign.Center
-                )
-
-                Spacer(modifier = Modifier.size(16.dp))
-
                 countryEmissionInfo?.let {
-                    val co2 = (countryEmissionInfo.emissions.co2 / 1_000_000).toInt()
-                    val percentage = (countryEmissionInfo.emissions.co2 / countryEmissionInfo.worldEmissions.co2).toPercent(2)
-                    Text("co2 = $co2 Million Tonnes (2022)")
-                    Text("rank = ${countryEmissionInfo.rank} ($percentage)")
-                }
+                    countryAssetEmissionsList?.let {
+                        Text(
+                            text = country.name,
+                            style = MaterialTheme.typography.titleLarge,
+                            textAlign = TextAlign.Center
+                        )
 
-                Spacer(modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(16.dp))
 
-                countryAssetEmissionsList?.let {
-                    SectorEmissionsPieChart(countryAssetEmissionsList)
+                        val co2 = (countryEmissionInfo.emissions.co2 / 1_000_000).toInt()
+                        val percentage = (countryEmissionInfo.emissions.co2 / countryEmissionInfo.worldEmissions.co2).toPercent(2)
+
+                        Text(text = "co2 = $co2 Million Tonnes (2022)")
+                        Text(text = "rank = ${countryEmissionInfo.rank} ($percentage)")
+
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        SectorEmissionsPieChart(countryAssetEmissionsList)
+                    }
                 }
             }
         }


### PR DESCRIPTION
The existing approach for calling the API at https://api.climatetrace.org/v4/country/emissions?countries=ANT results in receiving an empty array. This outcome isn't presently handled in our data class and the Ktor JSON serialization workflow.

To replicate the issue, initiate a search for Netherlands Antilles, which leads to the application crashing.


https://github.com/joreilly/ClimateTraceKMP/assets/4012000/02d8194e-864c-47af-a059-21914294532e


https://github.com/joreilly/ClimateTraceKMP/assets/4012000/3b5558e3-d6ff-40f9-bd8c-18345f9c1d00



@joreilly please review
