### PR TITLE
[iOS] Show progress view while loading countries and UI fixes

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -52,27 +52,43 @@ struct CountryListView: View {
     @State var query: String = ""
     
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(viewModel.countryList.filter { query.isEmpty ||  $0.name.contains(query)}, id: \.self) { country in
-                    NavigationLink(destination: CountryInfoDetailedViewShared(country: country)) {
-                        HStack {
-                            Text(country.name).font(.headline)
+            NavigationView {
+                ZStack {
+                    List {
+                        ForEach(viewModel.countryList.filter { query.isEmpty || $0.name.contains(query) }, id: \.self) { country in
+                            NavigationLink(destination: CountryInfoDetailedViewShared(country: country)) {
+                                HStack {
+                                    Text(country.name).font(.headline)
+                                }
+                            }
+                        }
+                    }
+                    .searchable(text: $query)
+
+                    // Conditional display of the ProgressView
+                    if let isLoading = viewModel.isLoadingCountries.value_ as? Bool, isLoading {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                            .scaleEffect(1.5)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if viewModel.countryList.filter({ query.isEmpty || $0.name.contains(query) }).isEmpty {
+                        // Conditional display of text when query result is empty from search bar
+                        Text("No Countries Found!")
+                            .font(.headline)
+                            .foregroundColor(.gray)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
+                }
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .principal) {
+                        VStack {
+                            Text("ClimateTrace").font(.headline)
                         }
                     }
                 }
             }
-            .searchable(text: $query)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    VStack {
-                        Text("ClimateTrace").font(.headline)
-                    }
-                }
-            }
         }
-    }
 }
 
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -64,6 +64,7 @@ struct CountryListView: View {
                         }
                     }
                     .searchable(text: $query)
+                    .disableAutocorrection(true)
 
                     // Conditional display of the ProgressView
                     if let isLoading = viewModel.isLoadingCountries.value_ as? Bool, isLoading {


### PR DESCRIPTION
- show  "No Countries Found!" text when user search doesn't match countries list.
-  Disable disableAutocorrection for search bar.


@joreilly please review

https://github.com/joreilly/ClimateTraceKMP/assets/4012000/55d39017-443b-406f-99b0-eb09f4918c85

https://github.com/joreilly/ClimateTraceKMP/assets/4012000/ed644994-66d0-4e67-bd65-170306770219





