### PR TITLE
Add data persistence for list of countries with kstore

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -63,9 +63,11 @@ kotlin {
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
 
-            
+
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
+
+            implementation(libs.kstore)
 
             implementation(libs.kotlinx.coroutines)
             implementation(libs.bundles.ktor.common)
@@ -82,22 +84,27 @@ kotlin {
 
         jsMain.dependencies {
             implementation(compose.html.core)
+            implementation(libs.kstore.storage)
         }
 
         androidMain.dependencies {
             implementation(libs.compose.ui.tooling.preview)
             implementation(libs.androidx.activity.compose)
-
+            implementation(libs.koin.android)
+            implementation(libs.kstore.file)
             implementation(libs.ktor.client.android)
         }
 
         desktopMain.dependencies {
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:${libs.versions.kotlinx.coroutines}")
             implementation(compose.desktop.currentOs)
+            implementation(libs.harawata.appdirs)
+            implementation(libs.kstore.file)
             implementation(libs.ktor.client.java)
         }
 
         appleMain.dependencies {
+            implementation(libs.kstore.file)
             implementation(libs.ktor.client.darwin)
         }
 
@@ -107,6 +114,12 @@ kotlin {
         // Adds the desktop test dependency
         desktopTest.dependencies {
             implementation(compose.desktop.currentOs)
+        }
+
+        val wasmJsMain by getting
+
+        wasmJsMain.dependencies {
+            implementation(libs.kstore.storage)
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/dev/johnoreilly/climatetrace/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/dev/johnoreilly/climatetrace/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        initKoin()
+        initKoin(this)
 
         setContent {
             MaterialTheme {

--- a/composeApp/src/androidMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.android.kt
+++ b/composeApp/src/androidMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.android.kt
@@ -1,0 +1,21 @@
+package dev.johnoreilly.climatetrace.di
+
+import android.content.Context
+import dev.johnoreilly.climatetrace.remote.Country
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.file.storeOf
+import okio.Path.Companion.toPath
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+fun initKoin(context: Context) = initKoin(enableNetworkLogs = false) {
+    androidContext(context)
+}
+
+actual fun dataModule(): Module = module {
+    single<KStore<List<Country>>> {
+        val filesDir: String = androidContext().filesDir.path
+        storeOf(file = "$filesDir/countries.json".toPath(), default = emptyList())
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/data/ClimateTraceRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/data/ClimateTraceRepository.kt
@@ -1,0 +1,16 @@
+package dev.johnoreilly.climatetrace.data
+
+import dev.johnoreilly.climatetrace.remote.ClimateTraceApi
+import dev.johnoreilly.climatetrace.remote.Country
+import io.github.xxfast.kstore.KStore
+
+class ClimateTraceRepository(
+    private val store: KStore<List<Country>>,
+    private val api: ClimateTraceApi
+) {
+    suspend fun fetchCountries() : List<Country> {
+        val countries: List<Country>? = store.get()
+        if (countries.isNullOrEmpty()) return api.fetchCountries().also { store.set(it) }
+        return countries
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.climatetrace.di
 
+import dev.johnoreilly.climatetrace.data.ClimateTraceRepository
 import dev.johnoreilly.climatetrace.remote.ClimateTraceApi
 import dev.johnoreilly.climatetrace.viewmodel.ClimateTraceViewModel
 import io.ktor.client.HttpClient
@@ -10,7 +11,9 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import org.koin.core.context.loadKoinModules
 import org.koin.core.context.startKoin
+import org.koin.core.module.Module
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.module
 
@@ -20,15 +23,16 @@ fun initKoin(enableNetworkLogs: Boolean = false, appDeclaration: KoinAppDeclarat
         modules(commonModule(enableNetworkLogs = enableNetworkLogs))
     }
 
-// called by iOS etc
-fun initKoin() = initKoin(enableNetworkLogs = false) {}
-
 fun commonModule(enableNetworkLogs: Boolean = false) = module {
     single { createJson() }
     single { createHttpClient(get(), enableNetworkLogs = enableNetworkLogs) }
     single { ClimateTraceApi(get()) }
     single { ClimateTraceViewModel() }
+    single { ClimateTraceRepository(get(), get()) }
+    loadKoinModules(dataModule())
 }
+
+expect fun dataModule(): Module
 
 fun createJson() = Json { isLenient = true; ignoreUnknownKeys = true }
 

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/ClimateTraceViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/ClimateTraceViewModel.kt
@@ -4,6 +4,7 @@ import com.rickclephas.kmm.viewmodel.KMMViewModel
 import com.rickclephas.kmm.viewmodel.MutableStateFlow
 import com.rickclephas.kmm.viewmodel.coroutineScope
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
+import dev.johnoreilly.climatetrace.data.ClimateTraceRepository
 import dev.johnoreilly.climatetrace.remote.ClimateTraceApi
 import dev.johnoreilly.climatetrace.remote.Country
 import dev.johnoreilly.climatetrace.remote.CountryAssetEmissionsInfo
@@ -15,6 +16,7 @@ import org.koin.core.component.inject
 
 open class ClimateTraceViewModel : KMMViewModel(), KoinComponent {
     private val climateTraceApi: ClimateTraceApi by inject()
+    private val climateTraceRepository: ClimateTraceRepository by inject()
 
     var year: String = "2022"
 
@@ -37,7 +39,7 @@ open class ClimateTraceViewModel : KMMViewModel(), KoinComponent {
     init {
         isLoadingCountries.value = true
         viewModelScope.coroutineScope.launch {
-            _countryList.value = climateTraceApi.fetchCountries().sortedBy { it.name }
+            _countryList.value = climateTraceRepository.fetchCountries().sortedBy { it.name }
             isLoadingCountries.value = false
         }
     }

--- a/composeApp/src/desktopMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.desktop.kt
@@ -1,0 +1,25 @@
+package dev.johnoreilly.climatetrace.di
+
+import dev.johnoreilly.climatetrace.remote.Country
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.file.storeOf
+import io.github.xxfast.kstore.file.utils.FILE_SYSTEM
+import net.harawata.appdirs.AppDirsFactory
+import okio.Path.Companion.toPath
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+private const val PACKAGE_NAME = "dev.johnoreilly.climatetrace"
+private const val VERSION = "1.0.0"
+private const val AUTHOR = "johnoreilly"
+
+actual fun dataModule(): Module = module {
+    single<KStore<List<Country>>> {
+        val filesDir: String = AppDirsFactory.getInstance()
+            .getUserDataDir(PACKAGE_NAME, VERSION, AUTHOR)
+
+        FILE_SYSTEM.createDirectories(filesDir.toPath())
+
+        storeOf(file = "$filesDir/countries.json".toPath(), default = emptyList())
+    }
+}

--- a/composeApp/src/iosMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.ios.kt
+++ b/composeApp/src/iosMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.ios.kt
@@ -1,0 +1,23 @@
+package dev.johnoreilly.climatetrace.di
+
+import dev.johnoreilly.climatetrace.remote.Country
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.file.storeOf
+import io.github.xxfast.kstore.file.utils.DocumentDirectory
+import io.github.xxfast.kstore.utils.ExperimentalKStoreApi
+import okio.Path.Companion.toPath
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import platform.Foundation.NSFileManager
+
+// called by iOS etc
+fun initKoin() = initKoin(enableNetworkLogs = false) {}
+
+@OptIn(ExperimentalKStoreApi::class)
+actual fun dataModule(): Module = module {
+    single<KStore<List<Country>>> {
+        val filesDir: String? = NSFileManager.defaultManager.DocumentDirectory?.relativePath
+        requireNotNull(filesDir) { "Document directory not found" }
+        storeOf(file = "$filesDir/countries.json".toPath(), default = emptyList())
+    }
+}

--- a/composeApp/src/jsMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.js.kt
+++ b/composeApp/src/jsMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.js.kt
@@ -1,0 +1,14 @@
+package dev.johnoreilly.climatetrace.di
+
+import dev.johnoreilly.climatetrace.remote.Country
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.storage.storeOf
+import io.github.xxfast.kstore.utils.ExperimentalKStoreApi
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual fun dataModule(): Module = module {
+    single<KStore<List<Country>>> {
+        storeOf(key = "countries", default = emptyList())
+    }
+}

--- a/composeApp/src/wasmJsMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.wasmjs.kt
@@ -1,0 +1,13 @@
+package dev.johnoreilly.climatetrace.di
+
+import dev.johnoreilly.climatetrace.remote.Country
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.storage.storeOf
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual fun dataModule(): Module = module {
+    single<KStore<List<Country>>> {
+        storeOf(key = "countries", default = emptyList())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ compose = "1.6.5"
 compose-compiler = "1.5.11-kt-2.0.0-RC1"
 compose-plugin = "1.6.2"
 composeWindowSize = "0.5.0"
+harawata-appdirs = "1.2.1"
 imageLoader = "1.7.8"
 junit = "4.13.2"
 koalaplot = "0.5.3"
@@ -24,6 +25,7 @@ kotlinx-coroutines = "1.8.0"
 kmpNativeCoroutines = "1.0.0-ALPHA-28-kotlin-2.0.0-RC1"
 kmmViewModel = "1.0.0-ALPHA-20-kotlin-2.0.0-RC1"
 ksp = "2.0.0-RC1-1.0.20"
+kstore = "0.8.0-SNAPSHOT"
 ktor = "3.0.0-wasm2"
 treemapChart = "0.1.1"
 voyager= "1.1.0-alpha03"
@@ -48,12 +50,17 @@ compose-foundation = { module = "androidx.compose.foundation:foundation", versio
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
 compose-window-size = { module = "dev.chrisbanes.material3:material3-window-size-class-multiplatform", version.ref = "composeWindowSize" }
 
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koinCompose" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 
 
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kmmViewModel = { group = "com.rickclephas.kmm", name = "kmm-viewmodel-core", version.ref = "kmmViewModel" }
+
+kstore = { module = "io.github.xxfast:kstore", version.ref = "kstore" }
+kstore-file = { module = "io.github.xxfast:kstore-file", version.ref = "kstore" }
+kstore-storage = { module = "io.github.xxfast:kstore-storage", version.ref = "kstore" }
 
 ktor = { group = "io.ktor", name = "ktor", version.ref = "ktor" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
@@ -67,6 +74,7 @@ ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.r
 ktor-client-java = { group = "io.ktor", name = "ktor-client-java", version.ref = "ktor" }
 
 voyager = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
+harawata-appdirs = { module = "net.harawata:appdirs", version.ref = "harawata-appdirs" }
 imageLoader = { module = "io.github.qdsfdhvh:image-loader", version.ref = "imageLoader" }
 koalaplot = { module = "io.github.koalaplot:koalaplot-core", version.ref = "koalaplot" }
 treemap-chart = { module = "io.github.overpas:treemap-chart", version.ref = "treemapChart" }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,9 +4,9 @@ import ComposeApp
 @main
 struct iOSApp: App {
     
-    init() {
-        KoinKt.doInitKoin()
-    }
+	init() {
+		Koin_iosKt.doInitKoin()
+	}
     
 	var body: some Scene {
 		WindowGroup {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,9 @@ dependencyResolutionManagement {
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
+
+        // TODO: Remove this after kstore-0.8.0 release
+        maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 


### PR DESCRIPTION
KStore will create these files on the following platforms 

- on Android, it will create  `countries.json` in `data/data/dev.johnoreilly.climatetrace/filesDir`
  <img width="672" src="https://github.com/joreilly/ClimateTraceKMP/assets/13775137/00bc4194-0623-4f08-b81b-6a54c7e87084">

- on Desktop, it will create `countries.json` (thanks to [harawata's appdirs](https://github.com/harawata/appdirs)) in
  - on Mac: `/Users/<Account>/Library/Application Support/dev.johnoreilly.climatetrace/1.0.0`
  - on Windows: `C:\Users\<Account>\AppData\johnoreilly\dev.johnoreilly.climatetrace`
  - on Linux: `/home/<Account>/.local/share/dev.johnoreilly.climatetrace`
<img width="692" alt="Screenshot 2024-04-29 at 11 02 24 pm" src="https://github.com/joreilly/ClimateTraceKMP/assets/13775137/1ce919fe-79e2-462c-98a2-e51132577b51">

- on iOS, it will create a file `countries.json` in `<DEVICE>/data/Containers/Data/Application/<APP-ID>/Documents`

- on WasmJS and JS browser targets, it will create an entry with key `countries` in `localStorage` 
 
  <img width="727" src="https://github.com/joreilly/ClimateTraceKMP/assets/13775137/3a33a0ac-9226-4009-86e1-ab1617fe4010">

