### PR TITLE
Add Rankings tab and sector drill-down

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -2,6 +2,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Leaderboard
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -19,6 +20,7 @@ import cafe.adriel.voyager.navigator.Navigator
 import dev.johnoreilly.climatetrace.di.commonModule
 import dev.johnoreilly.climatetrace.ui.AgentScreen
 import dev.johnoreilly.climatetrace.ui.ClimateTraceScreen
+import dev.johnoreilly.climatetrace.ui.RankingsScreen
 import dev.johnoreilly.climatetrace.ui.theme.ClimateTraceTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
@@ -45,6 +47,12 @@ fun App() {
                         NavigationBarItem(
                             selected = selectedIndex == 1,
                             onClick = { selectedIndex = 1 },
+                            icon = { Icon(Icons.Default.Leaderboard, contentDescription = "Rankings") },
+                            label = { Text("Rankings") }
+                        )
+                        NavigationBarItem(
+                            selected = selectedIndex == 2,
+                            onClick = { selectedIndex = 2 },
                             icon = { Icon(Icons.Default.AccountTree, contentDescription = "Agents") },
                             label = { Text("Agent") }
                         )
@@ -54,6 +62,7 @@ fun App() {
                 Column(Modifier.padding(paddingValues)) {
                     when (selectedIndex) {
                         0 -> Navigator(screen = ClimateTraceScreen())
+                        1 -> Navigator(screen = RankingsScreen())
                         else -> AgentScreen()
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/ClimateTraceApi.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/ClimateTraceApi.kt
@@ -82,6 +82,7 @@ data class Centroid(
 data class CountryEmissionsInfo(
     val country: String,
     val rank: Int,
+    val name: String? = null,
     val emissionsQuantity: Double = 0.0,
     val emissionsPerCapita: Double = 0.0,
     val percentage: Double = 0.0,

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryAssetEmissionsInfoTreeMapChart.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryAssetEmissionsInfoTreeMapChart.kt
@@ -39,13 +39,16 @@ import io.github.koalaplot.core.util.generateHueColorPalette
 import io.github.koalaplot.core.util.toString
 
 @Composable
-fun CountryAssetEmissionsInfoTreeMapChart(countryAssetEmissions: List<CountryAssetEmissionsInfo>) {
+fun CountryAssetEmissionsInfoTreeMapChart(
+    countryAssetEmissions: List<CountryAssetEmissionsInfo>,
+    selectedSector: String? = null,
+    onSectorChange: (String?) -> Unit = {}
+) {
     val leaves = remember(countryAssetEmissions) { buildAssetLeaves(countryAssetEmissions) }
     val tree = remember(leaves) { buildAssetTree(leaves) }
-    var selectedSector by remember(countryAssetEmissions) { mutableStateOf<String?>(null) }
 
     val toggle: (String) -> Unit = { sector ->
-        selectedSector = if (selectedSector == sector) null else sector
+        onSectorChange(if (selectedSector == sector) null else sector)
     }
 
     Column(Modifier.fillMaxWidth()) {

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryInfoDetailedView.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryInfoDetailedView.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -33,7 +35,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -95,6 +99,8 @@ fun CountryInfoDetailedViewSuccess(
     perCapitaRank: Int?,
     onYearSelected: (String) -> Unit
 ) {
+    var selectedSector by remember(viewState.country.id) { mutableStateOf<String?>(null) }
+
     Column(
         modifier = Modifier
             .verticalScroll(rememberScrollState())
@@ -132,7 +138,11 @@ fun CountryInfoDetailedViewSuccess(
             // Emissions by Sector Section
             val filteredCountryAssetEmissionsList = countryAssetEmissionsList.filter { it.sector != null }
             if (filteredCountryAssetEmissionsList.isNotEmpty()) {
-                EmissionsBySectorSection(countryAssetEmissionsList)
+                EmissionsBySectorSection(
+                    countryAssetEmissionsList = countryAssetEmissionsList,
+                    selectedSector = selectedSector,
+                    onSectorChange = { selectedSector = it }
+                )
             } else {
                 Surface(
                     tonalElevation = 1.dp,
@@ -153,7 +163,11 @@ fun CountryInfoDetailedViewSuccess(
 
         // Assets Section
         if (viewState.assets.isNotEmpty()) {
-            AssetsSection(viewState.assets)
+            AssetsSection(
+                assets = viewState.assets,
+                selectedSector = selectedSector,
+                onClearSector = { selectedSector = null }
+            )
         }
     }
 }
@@ -209,7 +223,11 @@ private fun EmissionsSummarySection(
 }
 
 @Composable
-private fun EmissionsBySectorSection(countryAssetEmissionsList: List<dev.johnoreilly.climatetrace.remote.CountryAssetEmissionsInfo>) {
+private fun EmissionsBySectorSection(
+    countryAssetEmissionsList: List<dev.johnoreilly.climatetrace.remote.CountryAssetEmissionsInfo>,
+    selectedSector: String?,
+    onSectorChange: (String?) -> Unit
+) {
     Surface(
         tonalElevation = 1.dp,
         shape = MaterialTheme.shapes.medium,
@@ -223,14 +241,29 @@ private fun EmissionsBySectorSection(countryAssetEmissionsList: List<dev.johnore
                 color = MaterialTheme.colorScheme.primary
             )
             Spacer(modifier = Modifier.size(12.dp))
-            CountryAssetEmissionsInfoTreeMapChart(countryAssetEmissionsList)
+            CountryAssetEmissionsInfoTreeMapChart(
+                countryAssetEmissions = countryAssetEmissionsList,
+                selectedSector = selectedSector,
+                onSectorChange = onSectorChange
+            )
         }
     }
 }
 
+private fun prettySectorName(sector: String): String =
+    sector.replace("-", " ").replaceFirstChar { it.uppercase() }
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AssetsSection(assets: List<Asset>) {
+private fun AssetsSection(
+    assets: List<Asset>,
+    selectedSector: String?,
+    onClearSector: () -> Unit
+) {
     val navigator = LocalNavigator.current
+    val filtered = remember(assets, selectedSector) {
+        if (selectedSector == null) assets else assets.filter { it.sector == selectedSector }
+    }
 
     Surface(
         tonalElevation = 1.dp,
@@ -238,14 +271,47 @@ private fun AssetsSection(assets: List<Asset>) {
         color = MaterialTheme.colorScheme.surface
     ) {
         Column(modifier = Modifier.padding(16.dp).fillMaxWidth()) {
-            Text(
-                text = "Top Emission Sources",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.primary
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = if (selectedSector != null) {
+                        "Top Sources · ${prettySectorName(selectedSector)}"
+                    } else {
+                        "Top Emission Sources"
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.weight(1f)
+                )
+                if (selectedSector != null) {
+                    AssistChip(
+                        onClick = onClearSector,
+                        label = { Text("All sectors") },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Clear filter",
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                    )
+                }
+            }
             Spacer(modifier = Modifier.size(8.dp))
 
-            assets.forEachIndexed { index, asset ->
+            if (filtered.isEmpty()) {
+                Text(
+                    text = "No tracked sources in this sector.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+                return@Column
+            }
+
+            filtered.forEachIndexed { index, asset ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -302,7 +368,7 @@ private fun AssetsSection(assets: List<Asset>) {
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                if (index < assets.size - 1) {
+                if (index < filtered.size - 1) {
                     HorizontalDivider()
                 }
             }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/RankingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/RankingsScreen.kt
@@ -1,0 +1,190 @@
+package dev.johnoreilly.climatetrace.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import dev.carlsen.flagkit.FlagKit
+import dev.johnoreilly.climatetrace.remote.Country
+import dev.johnoreilly.climatetrace.remote.CountryEmissionsInfo
+import dev.johnoreilly.climatetrace.ui.utils.alpha3ToAlpha2
+import dev.johnoreilly.climatetrace.ui.utils.formatEmissionsQuantity
+import dev.johnoreilly.climatetrace.viewmodel.CountryListUIState
+import dev.johnoreilly.climatetrace.viewmodel.CountryListViewModel
+import io.github.koalaplot.core.util.toString
+import org.koin.compose.koinInject
+
+private enum class RankingMode { Total, PerCapita }
+
+class RankingsScreen : Screen {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val viewModel = koinInject<CountryListViewModel>()
+        val state by viewModel.viewState.collectAsState()
+
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(title = { Text("Rankings") })
+            }
+        ) { paddingValues ->
+            Column(Modifier.padding(paddingValues).fillMaxSize()) {
+                when (val s = state) {
+                    is CountryListUIState.Loading -> {
+                        Column(modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center)) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                    is CountryListUIState.Error -> {
+                        Text("Error: ${s.message}", modifier = Modifier.padding(16.dp))
+                    }
+                    is CountryListUIState.Success -> {
+                        RankingsContent(s)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RankingsContent(state: CountryListUIState.Success) {
+    var mode by remember { mutableIntStateOf(RankingMode.Total.ordinal) }
+    val countriesById = remember(state.countryList) {
+        state.countryList.associateBy { it.id }
+    }
+    val rows = remember(state.rankingsList, mode) {
+        when (mode) {
+            RankingMode.Total.ordinal ->
+                state.rankingsList
+                    .filter { it.emissionsQuantity > 0 }
+                    .sortedByDescending { it.emissionsQuantity }
+            else ->
+                state.rankingsList
+                    .filter { it.emissionsPerCapita > 0 }
+                    .sortedByDescending { it.emissionsPerCapita }
+        }
+    }
+
+    Column {
+        TabRow(selectedTabIndex = mode) {
+            Tab(
+                selected = mode == RankingMode.Total.ordinal,
+                onClick = { mode = RankingMode.Total.ordinal },
+                text = { Text("Total") }
+            )
+            Tab(
+                selected = mode == RankingMode.PerCapita.ordinal,
+                onClick = { mode = RankingMode.PerCapita.ordinal },
+                text = { Text("Per Capita") }
+            )
+        }
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            itemsIndexed(rows) { idx, info ->
+                val valueText = if (mode == RankingMode.Total.ordinal) {
+                    formatEmissionsQuantity(info.emissionsQuantity)
+                } else {
+                    "${info.emissionsPerCapita.toString(1)} t"
+                }
+                RankingRow(
+                    rank = idx + 1,
+                    info = info,
+                    valueText = valueText,
+                    country = countriesById[info.country],
+                    perCapitaRank = state.perCapitaRankings[info.country]
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RankingRow(
+    rank: Int,
+    info: CountryEmissionsInfo,
+    valueText: String,
+    country: Country?,
+    perCapitaRank: Int?
+) {
+    val navigator = LocalNavigator.current
+    Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(enabled = country != null) {
+                    country?.let { navigator?.push(CountryEmissionsScreen(it, perCapitaRank)) }
+                }
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = "#$rank",
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+                modifier = Modifier.width(44.dp)
+            )
+            Box(
+                modifier = Modifier
+                    .size(width = 32.dp, height = 22.dp)
+                    .clip(RoundedCornerShape(3.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                val flag = alpha3ToAlpha2(info.country)?.let { FlagKit.getFlag(it) }
+                flag?.let {
+                    Image(
+                        imageVector = it,
+                        contentDescription = info.name ?: info.country,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = info.name ?: country?.name ?: info.country,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = valueText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        HorizontalDivider()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/CountryListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/CountryListViewModel.kt
@@ -6,6 +6,7 @@ import com.rickclephas.kmp.observableviewmodel.ViewModel
 import com.rickclephas.kmp.observableviewmodel.coroutineScope
 import dev.johnoreilly.climatetrace.data.ClimateTraceRepository
 import dev.johnoreilly.climatetrace.remote.Country
+import dev.johnoreilly.climatetrace.remote.CountryEmissionsInfo
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -19,7 +20,8 @@ sealed class CountryListUIState {
     data class Success(
         val countryList: List<Country>,
         val rankings: Map<String, Int> = emptyMap(),
-        val perCapitaRankings: Map<String, Int> = emptyMap()
+        val perCapitaRankings: Map<String, Int> = emptyMap(),
+        val rankingsList: List<CountryEmissionsInfo> = emptyList()
     ) : CountryListUIState()
 }
 
@@ -42,7 +44,12 @@ open class CountryListViewModel : ViewModel(), KoinComponent {
                     .sortedByDescending { it.emissionsPerCapita }
                     .mapIndexed { index, info -> info.country to (index + 1) }
                     .toMap()
-                _viewState.value = CountryListUIState.Success(countries, rankings, perCapitaRankings)
+                _viewState.value = CountryListUIState.Success(
+                    countryList = countries,
+                    rankings = rankings,
+                    perCapitaRankings = perCapitaRankings,
+                    rankingsList = rankingsResponse.rankings
+                )
 
             } catch (e: Exception) {
                 _viewState.value = CountryListUIState.Error(e.message ?: "Unknown Error")


### PR DESCRIPTION
## Summary

- **Rankings tab** — new bottom-nav destination (`Leaderboard` icon) showing all countries sorted by total CO₂e or per-capita emissions, switchable via a `TabRow`. Reuses the `/rankings/countries` response already fetched on app start, so there's no new network call. Tapping a row pushes `CountryEmissionsScreen` and forwards the per-capita rank.
- **Sector drill-down** — `selectedSector` state is now hoisted from the treemap into `CountryInfoDetailedViewSuccess` and shared with the assets section. Tapping a treemap block or legend row both dims non-matching sectors and filters the "Top Emission Sources" list client-side. The list title flips to `"Top Sources · <Sector>"` and an "All sectors" `AssistChip` appears to clear the filter. Resets when the country changes.
- **Model field** — `CountryEmissionsInfo.name` is now deserialized (the API was returning it; we were ignoring it). Lets the Rankings screen show country names without a separate lookup.
