### PR TITLE
Add ISS Tracker screen with live position, map, and country emissions

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -99,6 +99,9 @@ kotlin {
 
             implementation(libs.markdown.renderer)
 
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor3)
+
             implementation(libs.koog.agents)
             implementation(libs.koog.prompt.executor.llms.all)
             implementation(libs.koog.prompt.executor.litert.client)

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.Leaderboard
 import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.SatelliteAlt
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -17,11 +18,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.navigator.Navigator
+import coil3.ImageLoader
+import coil3.compose.setSingletonImageLoaderFactory
+import coil3.network.ktor3.KtorNetworkFetcherFactory
 import dev.johnoreilly.climatetrace.di.commonModule
 import dev.johnoreilly.climatetrace.ui.AgentScreen
 import dev.johnoreilly.climatetrace.ui.ClimateTraceScreen
+import dev.johnoreilly.climatetrace.ui.IssTrackerScreen
 import dev.johnoreilly.climatetrace.ui.RankingsScreen
 import dev.johnoreilly.climatetrace.ui.theme.ClimateTraceTheme
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
 
@@ -33,6 +42,29 @@ fun App() {
         modules(commonModule())
     }) {
         ClimateTraceTheme {
+            // OSM's tile usage policy (https://operations.osmfoundation.org/policies/tiles/)
+            // asks for a descriptive User-Agent identifying the app.
+            setSingletonImageLoaderFactory { context ->
+                ImageLoader.Builder(context)
+                    .components {
+                        add(
+                            KtorNetworkFetcherFactory(
+                                httpClient = {
+                                    HttpClient {
+                                        defaultRequest {
+                                            header(
+                                                HttpHeaders.UserAgent,
+                                                "ClimateTraceKMP/1.0 (+https://github.com/joreilly/ClimateTraceKMP)"
+                                            )
+                                        }
+                                    }
+                                }
+                            )
+                        )
+                    }
+                    .build()
+            }
+
             var selectedIndex by remember { mutableIntStateOf(0) }
 
             Scaffold(
@@ -53,6 +85,12 @@ fun App() {
                         NavigationBarItem(
                             selected = selectedIndex == 2,
                             onClick = { selectedIndex = 2 },
+                            icon = { Icon(Icons.Default.SatelliteAlt, contentDescription = "ISS Tracker") },
+                            label = { Text("ISS") }
+                        )
+                        NavigationBarItem(
+                            selected = selectedIndex == 3,
+                            onClick = { selectedIndex = 3 },
                             icon = { Icon(Icons.Default.AccountTree, contentDescription = "Agents") },
                             label = { Text("Agent") }
                         )
@@ -63,6 +101,7 @@ fun App() {
                     when (selectedIndex) {
                         0 -> Navigator(screen = ClimateTraceScreen())
                         1 -> Navigator(screen = RankingsScreen())
+                        2 -> Navigator(screen = IssTrackerScreen())
                         else -> AgentScreen()
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/data/ClimateTraceRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/data/ClimateTraceRepository.kt
@@ -2,14 +2,26 @@ package dev.johnoreilly.climatetrace.data
 
 import dev.johnoreilly.climatetrace.remote.ClimateTraceApi
 import dev.johnoreilly.climatetrace.remote.Country
+import dev.johnoreilly.climatetrace.remote.IssPosition
+import dev.johnoreilly.climatetrace.remote.IssPositionApi
 import dev.johnoreilly.climatetrace.remote.PopulationApi
+import dev.johnoreilly.climatetrace.remote.ReverseGeocodeApi
+import dev.johnoreilly.climatetrace.ui.utils.alpha2ToAlpha3
 import io.github.xxfast.kstore.KStore
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
 
 
 class ClimateTraceRepository(
     private val store: KStore<List<Country>>,
     private val climateTraceApi: ClimateTraceApi,
-    private val populationApi: PopulationApi
+    private val populationApi: PopulationApi,
+    private val issPositionApi: IssPositionApi,
+    private val reverseGeocodeApi: ReverseGeocodeApi,
 ) {
     suspend fun fetchCountries() : List<Country> {
         val countries: List<Country>? = store.get()
@@ -30,4 +42,31 @@ class ClimateTraceRepository(
     suspend fun fetchRankings(year: String) = climateTraceApi.fetchRankings(year)
 
     suspend fun getPopulation(countryCode: String) = populationApi.getPopulation(countryCode)
+
+    fun pollISSPosition(): Flow<IssPosition> = flow {
+        while (true) {
+            try {
+                val position = issPositionApi.fetchISSPosition().iss_position
+                if (currentCoroutineContext().isActive) {
+                    emit(position)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // ignore transient failures, next poll will retry
+            }
+            delay(ISS_POLL_INTERVAL_MS)
+        }
+    }
+
+    // Returns the ISO alpha-3 country code (matching ClimateTrace's Country.id) for the given
+    // coordinates, or null if they're over open ocean / no country match was found.
+    suspend fun reverseGeocodeCountry(latitude: Double, longitude: Double): String? {
+        val alpha2 = reverseGeocodeApi.reverseGeocode(latitude, longitude).countryCode
+        return alpha2?.let { alpha2ToAlpha3(it) }
+    }
+
+    companion object {
+        private const val ISS_POLL_INTERVAL_MS = 10_000L
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/di/Koin.kt
@@ -4,11 +4,14 @@ import dev.johnoreilly.climatetrace.agent.AgentProvider
 import dev.johnoreilly.climatetrace.agent.ClimateTraceAgentProvider
 import dev.johnoreilly.climatetrace.data.ClimateTraceRepository
 import dev.johnoreilly.climatetrace.remote.ClimateTraceApi
+import dev.johnoreilly.climatetrace.remote.IssPositionApi
 import dev.johnoreilly.climatetrace.remote.PopulationApi
+import dev.johnoreilly.climatetrace.remote.ReverseGeocodeApi
 import dev.johnoreilly.climatetrace.viewmodel.AgentViewModel
 import dev.johnoreilly.climatetrace.viewmodel.AssetDetailViewModel
 import dev.johnoreilly.climatetrace.viewmodel.CountryDetailsViewModel
 import dev.johnoreilly.climatetrace.viewmodel.CountryListViewModel
+import dev.johnoreilly.climatetrace.viewmodel.IssTrackerViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -35,11 +38,14 @@ fun commonModule(enableNetworkLogs: Boolean = false) = module {
     single { createHttpClient(get(), enableNetworkLogs = enableNetworkLogs) }
     single { ClimateTraceApi(get()) }
     single { PopulationApi(get()) }
+    single { IssPositionApi(get()) }
+    single { ReverseGeocodeApi(get()) }
     single { CountryListViewModel() }
     single { CountryDetailsViewModel() }
     factory { AssetDetailViewModel() }
     single { AgentViewModel(get()) }
-    single { ClimateTraceRepository(get(), get(), get()) }
+    single { IssTrackerViewModel() }
+    single { ClimateTraceRepository(get(), get(), get(), get(), get()) }
     single<AgentProvider> { ClimateTraceAgentProvider(get()) }
     includes(dataModule())
 }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/IssPositionApi.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/IssPositionApi.kt
@@ -1,0 +1,19 @@
+package dev.johnoreilly.climatetrace.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IssPosition(val latitude: Double, val longitude: Double, val timestamp: Long = -1)
+
+@Serializable
+data class IssResponse(val message: String, val iss_position: IssPosition, val timestamp: Long)
+
+class IssPositionApi(
+    private val client: HttpClient,
+    private val baseUrl: String = "https://people-in-space-proxy.ew.r.appspot.com",
+) {
+    suspend fun fetchISSPosition() = client.get("$baseUrl/iss-now.json").body<IssResponse>()
+}

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/ReverseGeocodeApi.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/remote/ReverseGeocodeApi.kt
@@ -1,0 +1,29 @@
+package dev.johnoreilly.climatetrace.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReverseGeocodeResult(
+    val countryCode: String? = null,
+    val countryName: String? = null,
+)
+
+// BigDataCloud's client-side reverse geocode endpoint: free, no API key, CORS-enabled.
+// countryCode/countryName come back blank when the coordinates are over open ocean.
+class ReverseGeocodeApi(
+    private val client: HttpClient,
+    private val baseUrl: String = "https://api.bigdatacloud.net/data/reverse-geocode-client",
+) {
+    suspend fun reverseGeocode(latitude: Double, longitude: Double): ReverseGeocodeResult {
+        return client.get(baseUrl) {
+            url {
+                parameters.append("latitude", latitude.toString())
+                parameters.append("longitude", longitude.toString())
+                parameters.append("localityLanguage", "en")
+            }
+        }.body<ReverseGeocodeResult>()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryBasicInfoView.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryBasicInfoView.kt
@@ -1,0 +1,169 @@
+package dev.johnoreilly.climatetrace.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.johnoreilly.climatetrace.remote.CountryAssetEmissionsInfo
+import dev.johnoreilly.climatetrace.ui.utils.formatEmissionsQuantity
+import dev.johnoreilly.climatetrace.ui.utils.sectorIcon
+import dev.johnoreilly.climatetrace.viewmodel.CountryDetailsUIState
+import io.github.koalaplot.core.util.toString
+
+// Stripped-down companion to CountryInfoDetailedView: header, key stats, year
+// picker, trend, and a compact sector breakdown - no asset list or treemap.
+@Composable
+fun CountryBasicEmissionsView(
+    viewState: CountryDetailsUIState,
+    perCapitaRank: Int? = null,
+    onYearSelected: (String) -> Unit = {}
+) {
+    when (viewState) {
+        CountryDetailsUIState.NoCountrySelected -> {
+            Column(Modifier.fillMaxSize().wrapContentSize(Alignment.Center)) {
+                Text(text = "No Country Selected.", style = MaterialTheme.typography.titleMedium)
+            }
+        }
+        is CountryDetailsUIState.Loading -> {
+            Column(Modifier.fillMaxSize().wrapContentSize(Alignment.Center)) {
+                CircularProgressIndicator()
+            }
+        }
+        is CountryDetailsUIState.Error -> {
+            Column(Modifier.fillMaxSize().wrapContentSize(Alignment.Center)) {
+                Text(text = "Error", style = MaterialTheme.typography.titleMedium)
+            }
+        }
+        is CountryDetailsUIState.Success -> {
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                CountryHeader(viewState)
+
+                YearChips(viewState.year, viewState.availableYears, onYearSelected)
+
+                val countryEmissionInfo = viewState.countryEmissionInfo
+                if (countryEmissionInfo != null) {
+                    KeyFiguresRow(
+                        co2Value = formatEmissionsQuantity(countryEmissionInfo.emissionsQuantity),
+                        co2PercentChange = countryEmissionInfo.emissionsPercentChange,
+                        rank = countryEmissionInfo.rank,
+                        share = "${countryEmissionInfo.percentage.toString(2)}%",
+                        perCapita = "${countryEmissionInfo.emissionsPerCapita.toString(1)} t",
+                        perCapitaRank = perCapitaRank
+                    )
+                } else {
+                    Text(
+                        text = "No emissions data available for ${viewState.year}.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
+                if (viewState.yearlyEmissions.size >= 2) {
+                    CO2TrendSparkline(
+                        yearlyEmissions = viewState.yearlyEmissions,
+                        selectedYear = viewState.year,
+                        modifier = Modifier.fillMaxWidth(),
+                        onYearSelected = onYearSelected
+                    )
+                }
+
+                val topSectors = viewState.countryAssetEmissionsList
+                    .filter { it.sector != null && it.subsector == null && it.emissionsQuantity > 0 }
+                    .sortedByDescending { it.emissionsQuantity }
+                    .take(5)
+                if (topSectors.isNotEmpty()) {
+                    TopSectorsList(topSectors)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TopSectorsList(sectors: List<CountryAssetEmissionsInfo>) {
+    Surface(
+        tonalElevation = 1.dp,
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surface,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Top Sectors",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.size(12.dp))
+            sectors.forEachIndexed { index, sector ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Surface(
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        modifier = Modifier.size(32.dp)
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = sectorIcon(sector.sector),
+                                contentDescription = sector.sector,
+                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+                    Spacer(Modifier.size(12.dp))
+                    Text(
+                        text = sector.sector?.let { prettySectorName(it) } ?: "Unknown",
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Spacer(Modifier.size(8.dp))
+                    Column(horizontalAlignment = Alignment.End) {
+                        Text(
+                            text = formatEmissionsQuantity(sector.emissionsQuantity),
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        Text(
+                            text = "${sector.percentage.toString(1)}%",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                if (index < sectors.size - 1) {
+                    Spacer(Modifier.size(2.dp))
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryInfoDetailedView.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryInfoDetailedView.kt
@@ -250,7 +250,7 @@ private fun EmissionsBySectorSection(
     }
 }
 
-private fun prettySectorName(sector: String): String =
+internal fun prettySectorName(sector: String): String =
     sector.replace("-", " ").replaceFirstChar { it.uppercase() }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -377,7 +377,7 @@ private fun AssetsSection(
 }
 
 @Composable
-private fun CountryHeader(viewState: CountryDetailsUIState.Success) {
+internal fun CountryHeader(viewState: CountryDetailsUIState.Success) {
     val c = viewState.country
     Surface(
         tonalElevation = 2.dp,
@@ -416,7 +416,7 @@ private fun CountryHeader(viewState: CountryDetailsUIState.Success) {
 }
 
 @Composable
-private fun KeyFiguresRow(
+internal fun KeyFiguresRow(
     co2Value: String,
     co2PercentChange: Double,
     rank: Int,
@@ -508,7 +508,7 @@ private fun StatCard(
 }
 
 @Composable
-private fun CO2TrendSparkline(
+internal fun CO2TrendSparkline(
     yearlyEmissions: Map<String, Double>,
     selectedYear: String,
     modifier: Modifier = Modifier,

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/IssMapView.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/IssMapView.kt
@@ -1,0 +1,78 @@
+package dev.johnoreilly.climatetrace.ui
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SatelliteAlt
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.floor
+import kotlin.math.ln
+import kotlin.math.tan
+
+// Low zoom level (45deg/tile) keeps the 3x3 tile grid stable across most ISS
+// polls, so we're not re-fetching OSM tiles on every position update.
+private const val MAP_ZOOM = 3
+
+// Renders a 3x3 grid of OpenStreetMap tiles (https://tile.openstreetmap.org)
+// centered on the given coordinates, with a marker positioned at the exact
+// sub-tile pixel offset using the standard slippy-map tile math:
+// https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+// The modifier determines the overall (square) size - e.g. fillMaxWidth().aspectRatio(1f) -
+// and each of the 9 tiles is sized to a third of that.
+@Composable
+fun IssMapView(latitude: Double, longitude: Double, modifier: Modifier = Modifier) {
+    val tilesPerAxis = 1 shl MAP_ZOOM
+
+    val latRad = latitude * PI / 180.0
+    val xTileFrac = (longitude + 180.0) / 360.0 * tilesPerAxis
+    val yTileFrac = (1.0 - ln(tan(latRad) + 1.0 / cos(latRad)) / PI) / 2.0 * tilesPerAxis
+
+    val originXTile = floor(xTileFrac).toInt() - 1
+    val originYTile = (floor(yTileFrac).toInt() - 1).coerceIn(0, tilesPerAxis - 1)
+
+    BoxWithConstraints(modifier = modifier.clip(RoundedCornerShape(8.dp))) {
+        val tileSize = maxWidth / 3
+
+        Column {
+            for (row in 0..2) {
+                Row {
+                    for (col in 0..2) {
+                        // Longitude wraps around the antimeridian; latitude does not.
+                        val tileX = ((originXTile + col) % tilesPerAxis + tilesPerAxis) % tilesPerAxis
+                        val tileY = (originYTile + row).coerceIn(0, tilesPerAxis - 1)
+                        AsyncImage(
+                            model = "https://tile.openstreetmap.org/$MAP_ZOOM/$tileX/$tileY.png",
+                            contentDescription = null,
+                            modifier = Modifier.size(tileSize)
+                        )
+                    }
+                }
+            }
+        }
+
+        val tileSizePx = tileSize.value.toDouble()
+        val markerX = (xTileFrac - originXTile) * tileSizePx
+        val markerY = (yTileFrac - originYTile) * tileSizePx
+
+        Icon(
+            imageVector = Icons.Default.SatelliteAlt,
+            contentDescription = "ISS position",
+            tint = Color.Red,
+            modifier = Modifier
+                .offset(x = markerX.dp - 12.dp, y = markerY.dp - 12.dp)
+                .size(24.dp)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/IssTrackerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/IssTrackerScreen.kt
@@ -1,0 +1,208 @@
+package dev.johnoreilly.climatetrace.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import dev.johnoreilly.climatetrace.viewmodel.CountryDetailsViewModel
+import dev.johnoreilly.climatetrace.viewmodel.CountryListUIState
+import dev.johnoreilly.climatetrace.viewmodel.CountryListViewModel
+import dev.johnoreilly.climatetrace.viewmodel.IssPositionUiState
+import dev.johnoreilly.climatetrace.viewmodel.IssTrackerViewModel
+import kotlin.math.roundToInt
+import org.koin.compose.koinInject
+
+class IssTrackerScreen : Screen {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val issTrackerViewModel = koinInject<IssTrackerViewModel>()
+        val issViewState by issTrackerViewModel.viewState.collectAsState()
+
+        val countryListViewModel = koinInject<CountryListViewModel>()
+        val countryListViewState by countryListViewModel.viewState.collectAsState()
+        val perCapitaRankings = (countryListViewState as? CountryListUIState.Success)?.perCapitaRankings ?: emptyMap()
+
+        val countryDetailsViewModel = koinInject<CountryDetailsViewModel>()
+        val countryDetailsViewState by countryDetailsViewModel.viewState.collectAsState()
+
+        LaunchedEffect(issViewState) {
+            (issViewState as? IssPositionUiState.OverCountry)?.let { state ->
+                countryDetailsViewModel.setCountry(state.country)
+            }
+        }
+
+        Scaffold(
+            topBar = { CenterAlignedTopAppBar(title = { Text("ISS Emissions Tracker") }) }
+        ) { paddingValues ->
+            Row(Modifier.padding(paddingValues).fillMaxSize()) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .verticalScroll(rememberScrollState()),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    IssPositionCard(issViewState)
+                    IssMapCard(issViewState)
+                }
+
+                VerticalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
+
+                Box(Modifier.weight(1f).fillMaxHeight()) {
+                    when (val state = issViewState) {
+                        is IssPositionUiState.OverCountry -> {
+                            CountryBasicEmissionsView(
+                                viewState = countryDetailsViewState,
+                                perCapitaRank = perCapitaRankings[state.country.id],
+                                onYearSelected = { year -> countryDetailsViewModel.setYear(year) }
+                            )
+                        }
+                        is IssPositionUiState.OverOcean -> {
+                            EmptyState(
+                                title = "Over the Ocean",
+                                message = "The ISS isn't currently over a country tracked by Climate TRACE."
+                            )
+                        }
+                        is IssPositionUiState.Error -> {
+                            EmptyState(title = "Error", message = state.message)
+                        }
+                        is IssPositionUiState.Loading -> {
+                            Column(Modifier.fillMaxSize().wrapContentSize(Alignment.Center)) {
+                                CircularProgressIndicator()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun issCoordinates(state: IssPositionUiState): Pair<Double, Double>? = when (state) {
+    is IssPositionUiState.OverCountry -> state.latitude to state.longitude
+    is IssPositionUiState.OverOcean -> state.latitude to state.longitude
+    else -> null
+}
+
+@Composable
+private fun IssPositionCard(state: IssPositionUiState) {
+    val coordinates = issCoordinates(state)
+    val latitude = coordinates?.first
+    val longitude = coordinates?.second
+
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "ISS Current Location",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                CoordinateDisplay(
+                    label = "Latitude",
+                    value = latitude?.let { formatCoordinate(it) } ?: "--",
+                    modifier = Modifier.weight(1f)
+                )
+
+                Spacer(Modifier.width(16.dp))
+
+                CoordinateDisplay(
+                    label = "Longitude",
+                    value = longitude?.let { formatCoordinate(it) } ?: "--",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IssMapCard(state: IssPositionUiState) {
+    val coordinates = issCoordinates(state) ?: return
+
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        IssMapView(
+            latitude = coordinates.first,
+            longitude = coordinates.second,
+            modifier = Modifier.padding(16.dp).fillMaxWidth().aspectRatio(1f)
+        )
+    }
+}
+
+@Composable
+private fun CoordinateDisplay(label: String, value: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.background,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+        }
+    }
+}
+
+private fun formatCoordinate(value: Double): String = ((value * 100).roundToInt() / 100.0).toString()

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/utils/IsoCountryCodes.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/utils/IsoCountryCodes.kt
@@ -70,3 +70,9 @@ private val alpha3ToAlpha2Map = mapOf(
 )
 
 fun alpha3ToAlpha2(code: String): String? = alpha3ToAlpha2Map[code.uppercase()]
+
+private val alpha2ToAlpha3Map: Map<String, String> by lazy {
+    alpha3ToAlpha2Map.entries.associate { (alpha3, alpha2) -> alpha2 to alpha3 }
+}
+
+fun alpha2ToAlpha3(code: String): String? = alpha2ToAlpha3Map[code.uppercase()]

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/IssTrackerViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/IssTrackerViewModel.kt
@@ -1,0 +1,55 @@
+package dev.johnoreilly.climatetrace.viewmodel
+
+import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
+import com.rickclephas.kmp.observableviewmodel.MutableStateFlow
+import com.rickclephas.kmp.observableviewmodel.ViewModel
+import com.rickclephas.kmp.observableviewmodel.coroutineScope
+import dev.johnoreilly.climatetrace.data.ClimateTraceRepository
+import dev.johnoreilly.climatetrace.remote.Country
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+
+sealed class IssPositionUiState {
+    data object Loading : IssPositionUiState()
+    data class Error(val message: String) : IssPositionUiState()
+    data class OverOcean(val latitude: Double, val longitude: Double) : IssPositionUiState()
+    data class OverCountry(val latitude: Double, val longitude: Double, val country: Country) : IssPositionUiState()
+}
+
+open class IssTrackerViewModel : ViewModel(), KoinComponent {
+    private val climateTraceRepository: ClimateTraceRepository by inject()
+
+    private val _viewState = MutableStateFlow<IssPositionUiState>(viewModelScope, IssPositionUiState.Loading)
+    @NativeCoroutinesState
+    val viewState: StateFlow<IssPositionUiState> = _viewState.asStateFlow()
+
+    private var countries: List<Country> = emptyList()
+
+    init {
+        viewModelScope.coroutineScope.launch {
+            try {
+                countries = climateTraceRepository.fetchCountries()
+            } catch (_: Exception) {
+                // country lookup will just fall back to "over ocean" until this succeeds on retry
+            }
+
+            climateTraceRepository.pollISSPosition().collect { position ->
+                try {
+                    val countryCode = climateTraceRepository.reverseGeocodeCountry(position.latitude, position.longitude)
+                    val country = countryCode?.let { code -> countries.find { it.id == code } }
+                    _viewState.value = if (country != null) {
+                        IssPositionUiState.OverCountry(position.latitude, position.longitude, country)
+                    } else {
+                        IssPositionUiState.OverOcean(position.latitude, position.longitude)
+                    }
+                } catch (e: Exception) {
+                    _viewState.value = IssPositionUiState.Error(e.message ?: "Unknown Error")
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ koogAgents = "1.1.1"
 koogPromptExecutorAll = "1.1.1-beta"
 markdownRenderer = "0.43.0"
 buildkonfig = "0.22.0"
+coil = "3.5.0"
 
 
 [libraries]
@@ -93,6 +94,9 @@ markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer-m3"
 
 molecule = { module = "app.cash.molecule:molecule-runtime", version.ref = "molecule" }
 mcp-kotlin = { group = "io.modelcontextprotocol", name = "kotlin-sdk", version.ref = "mcp" }
+
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 [bundles]
 ktor-common = ["ktor-client-core", "ktor-client-logging", "ktor-client-content-negotiation", "ktor-serialization-kotlinx-json"]


### PR DESCRIPTION
## Summary
- Adds a new "ISS" tab that polls the ISS's live lat/lon (same API PeopleInSpace uses), reverse-geocodes it to a country, and shows that country's Climate TRACE emissions data alongside a live OpenStreetMap view of the ISS's position.
- Side-by-side layout: position card + OSM map on the left, country header/key stats/year picker/trend/top sectors on the right (falls back to an "Over the Ocean" message when there's no country match).
- New `IssPositionApi` (ISS position), `ReverseGeocodeApi` (coords → country code via BigDataCloud's free client-side endpoint), `IssTrackerViewModel`, `IssMapView` (OSM tile grid + marker via Coil3), `IssTrackerScreen`, and `CountryBasicEmissionsView` (a lighter-weight companion to the existing detailed country view).
- `CountryHeader`, `KeyFiguresRow`, `CO2TrendSparkline`, and `prettySectorName` in `CountryInfoDetailedView.kt` changed from `private` to `internal` so the new basic view can reuse them instead of duplicating.

## Test plan
- [x] All four KMP targets compile (Android, iOS, JVM/Desktop, wasmJs)
- [x] Verified live in the running desktop app: ISS position polls and updates, OSM tiles render with correct marker placement, "Over the Ocean" state renders correctly
- [x] Verified the reused `CountryHeader`/`KeyFiguresRow` render correctly with real data via the existing Climate tab (ISS stayed over ocean for the whole test session, so didn't get a live screenshot of the country-emissions branch itself, but it's built from the same proven components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)