### PR TITLE
UX improvements: error states, loading messages, search, and agent welcome

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/AgentsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/AgentsScreen.kt
@@ -1,6 +1,7 @@
 package dev.johnoreilly.climatetrace.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -122,36 +123,45 @@ private fun AgentScreenContent(
                 .padding(paddingValues)
                 .imePadding()
         ) {
-            // Messages list
-            LazyColumn(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(horizontal = AppDimension.spacingMedium),
-                state = listState,
-                verticalArrangement = Arrangement.spacedBy(AppDimension.spacingMedium)
-            ) {
-                items(messages) { message ->
-                    when (message) {
-                        is Message.UserMessage -> UserMessageBubble(message.text)
-                        is Message.AgentMessage -> AgentMessageBubble(message.text)
-                        is Message.SystemMessage -> SystemMessageItem(message.text)
-                        is Message.ErrorMessage -> ErrorMessageItem(message.text)
-                        is Message.ToolCallMessage -> ToolCallMessageItem(message.text)
-                        is Message.ResultMessage -> ResultMessageItem(message.text)
+            if (messages.isEmpty() && !isLoading) {
+                WelcomeScreen(
+                    onPromptSelected = { prompt ->
+                        onInputTextChanged(prompt)
+                        onSendClicked()
                     }
-                }
+                )
+            } else {
+                // Messages list
+                LazyColumn(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(horizontal = AppDimension.spacingMedium),
+                    state = listState,
+                    verticalArrangement = Arrangement.spacedBy(AppDimension.spacingMedium)
+                ) {
+                    items(messages) { message ->
+                        when (message) {
+                            is Message.UserMessage -> UserMessageBubble(message.text)
+                            is Message.AgentMessage -> AgentMessageBubble(message.text)
+                            is Message.SystemMessage -> SystemMessageItem(message.text)
+                            is Message.ErrorMessage -> ErrorMessageItem(message.text)
+                            is Message.ToolCallMessage -> ToolCallMessageItem(message.text)
+                            is Message.ResultMessage -> ResultMessageItem(message.text)
+                        }
+                    }
 
-                // Typing indicator while waiting for agent response
-                if (isLoading) {
+                    // Typing indicator while waiting for agent response
+                    if (isLoading) {
+                        item {
+                            AgentTypingIndicator()
+                        }
+                    }
+
+                    // Add extra space at the bottom for better UX
                     item {
-                        AgentTypingIndicator()
+                        Spacer(modifier = Modifier.height(AppDimension.spacingMedium))
                     }
-                }
-
-                // Add extra space at the bottom for better UX
-                item {
-                    Spacer(modifier = Modifier.height(AppDimension.spacingMedium))
                 }
             }
 
@@ -487,6 +497,64 @@ private fun InputArea(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun WelcomeScreen(
+    onPromptSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val suggestedPrompts = listOf(
+        "Which country emits the most?",
+        "Compare emissions between UK and France",
+        "Show me the top 5 emitting countries",
+        "What are the main sectors contributing to emissions?"
+    )
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = AppDimension.spacingLarge, vertical = AppDimension.spacingMedium),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Ask About Climate Data",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "I can help you explore global emissions data, compare countries, and analyze trends.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(32.dp))
+        Text(
+            text = "Try asking:",
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        for (prompt in suggestedPrompts) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = { onPromptSelected(prompt) }),
+                shape = RoundedCornerShape(AppDimension.radiusMedium),
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                tonalElevation = 0.dp
+            ) {
+                Text(
+                    text = prompt,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
@@ -22,8 +22,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -32,6 +36,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.HorizontalDivider
@@ -48,6 +53,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowWidthSizeClass
@@ -70,19 +76,18 @@ class ClimateTraceScreen: Screen {
         val countryListViewModel = koinInject<CountryListViewModel>()
         val countryListViewState by countryListViewModel.viewState.collectAsState()
 
-        Column(Modifier) {
-            when (val state = countryListViewState) {
-                is CountryListUIState.Loading -> {
-                    Column(modifier = Modifier.fillMaxSize().fillMaxHeight().wrapContentSize(Alignment.Center)) {
-                        CircularProgressIndicator()
-                    }
+        when (val state = countryListViewState) {
+            is CountryListUIState.Loading -> {
+                Column(modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center), verticalArrangement = Arrangement.spacedBy(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+                    CircularProgressIndicator()
+                    Text("Loading global emissions data…", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
-                is CountryListUIState.Error -> {
-                    Text("Error")
-                }
-                is CountryListUIState.Success -> {
-                    CountryScreenSuccess(state.countryList, state.rankings, state.perCapitaRankings)
-                }
+            }
+            is CountryListUIState.Error -> {
+                ErrorState(message = state.message, onRetry = { countryListViewModel.refresh() })
+            }
+            is CountryListUIState.Success -> {
+                CountryScreenSuccess(state.countryList, state.rankings, state.perCapitaRankings)
             }
         }
     }
@@ -173,6 +178,7 @@ fun CountryListView(
     rankings: Map<String, Int> = emptyMap()
 ) {
     val searchQuery = remember { mutableStateOf("") }
+    var isSearching by remember { mutableStateOf(false) }
 
     Column {
         SearchableList(
@@ -181,7 +187,10 @@ fun CountryListView(
             countryList = countryList,
             selectedCountry = selectedCountry,
             countrySelected = countrySelected,
-            rankings = rankings
+            rankings = rankings,
+            isSearching = isSearching,
+            onSearchToggle = { isSearching = !isSearching },
+            onClearSearch = { isSearching = false; searchQuery.value = "" }
         )
     }
 }
@@ -196,7 +205,10 @@ fun SearchableList(
     countryList: List<Country>,
     selectedCountry: Country?,
     countrySelected: (country: Country) -> Unit,
-    rankings: Map<String, Int> = emptyMap()
+    rankings: Map<String, Int> = emptyMap(),
+    isSearching: Boolean = false,
+    onSearchToggle: () -> Unit = {},
+    onClearSearch: () -> Unit = {}
 ) {
     var sortMode by remember { mutableStateOf(CountrySort.Name) }
     val filteredCountryList = countryList
@@ -208,75 +220,150 @@ fun SearchableList(
             }
         }
     val keyboardController = LocalSoftwareKeyboardController.current
-    SearchBar(
-        query = searchQuery.value,
-        onQueryChange = onSearchQueryChange,
-        onSearch = {
-            onSearchQueryChange.invoke(searchQuery.value)
-            keyboardController?.hide()
-        },
-        placeholder = {
-            Text(text = "Search countries")
-        },
-        leadingIcon = {
-            Icon(
-                imageVector = Icons.Default.Search,
-                tint = MaterialTheme.colorScheme.onSurface,
-                contentDescription = "search"
-            )
-        },
-        trailingIcon = {
-            AnimatedVisibility(
-                visible = searchQuery.value.isNotBlank(),
-                enter = fadeIn(),
-                exit = fadeOut()
-            ) {
-                IconButton(onClick = {
-                    onSearchQueryChange("")
-                }) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        tint = MaterialTheme.colorScheme.onSurface,
-                        contentDescription = "clear_search"
-                    )
-                }
-            }
-        },
-        content = {
-            Row(
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                FilterChip(
-                    selected = sortMode == CountrySort.Name,
-                    onClick = { sortMode = CountrySort.Name },
-                    label = { Text("Name") }
+
+    // Sort chips always visible above the search bar
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        FilterChip(
+            selected = sortMode == CountrySort.Name,
+            onClick = { sortMode = CountrySort.Name },
+            label = { Text("Name") }
+        )
+        FilterChip(
+            selected = sortMode == CountrySort.Rank,
+            onClick = { sortMode = CountrySort.Rank },
+            label = { Text("Rank") }
+        )
+    }
+
+    if (isSearching) {
+        SearchBar(
+            query = searchQuery.value,
+            onQueryChange = onSearchQueryChange,
+            onSearch = {
+                onSearchQueryChange.invoke(searchQuery.value)
+                keyboardController?.hide()
+            },
+            placeholder = {
+                Text(text = "Search countries")
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    tint = MaterialTheme.colorScheme.onSurface,
+                    contentDescription = "search"
                 )
-                FilterChip(
-                    selected = sortMode == CountrySort.Rank,
-                    onClick = { sortMode = CountrySort.Rank },
-                    label = { Text("Rank") }
-                )
-            }
-            if (filteredCountryList.isEmpty()) {
-                EmptyState(message = "")
-            } else {
-                LazyColumn {
-                    items(filteredCountryList) { country ->
-                        CountryRow(
-                            country = country,
-                            selectedCountry = selectedCountry,
-                            countrySelected = countrySelected,
-                            rankings = rankings
+            },
+            trailingIcon = {
+                AnimatedVisibility(
+                    visible = searchQuery.value.isNotBlank(),
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    IconButton(onClick = { onClearSearch() }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            contentDescription = "clear_search"
                         )
                     }
                 }
+            },
+            content = {
+                if (filteredCountryList.isEmpty()) {
+                    EmptyState(message = "No matches for \"${searchQuery.value}\"")
+                } else {
+                    LazyColumn {
+                        items(filteredCountryList) { country ->
+                            CountryRow(
+                                country = country,
+                                selectedCountry = selectedCountry,
+                                countrySelected = countrySelected,
+                                rankings = rankings
+                            )
+                        }
+                    }
+                }
+            },
+            active = true,
+            onActiveChange = { onClearSearch() },
+            colors = SearchBarDefaults.colors(containerColor = MaterialTheme.colorScheme.background),
+        )
+    } else {
+        // Collapsed state: search button + list
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onSearchToggle)
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                contentDescription = "Search",
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Search countries…",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        if (filteredCountryList.isEmpty()) {
+            EmptyState()
+        } else {
+            LazyColumn {
+                items(filteredCountryList) { country ->
+                    CountryRow(
+                        country = country,
+                        selectedCountry = selectedCountry,
+                        countrySelected = countrySelected,
+                        rankings = rankings
+                    )
+                }
             }
-        },
-        active = true,
-        onActiveChange = {},
-        colors = SearchBarDefaults.colors(containerColor = MaterialTheme.colorScheme.background),
-    )
+        }
+    }
+}
+
+@Composable
+fun ErrorState(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize().wrapContentSize(Alignment.Center).padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.ErrorOutline,
+            contentDescription = "Error",
+            tint = MaterialTheme.colorScheme.error,
+            modifier = Modifier.size(48.dp)
+        )
+        Text(
+            text = "Unable to Load Data",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onErrorContainer
+        )
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.75f),
+            textAlign = TextAlign.Center
+        )
+        Button(onClick = onRetry) {
+            Icon(Icons.Default.Refresh, contentDescription = "Retry", modifier = Modifier.size(18.dp))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Retry")
+        }
+    }
 }
 
 @Composable
@@ -291,7 +378,7 @@ fun EmptyState(
     ) {
         Text(title ?: "No Countries Found!", style = MaterialTheme.typography.titleMedium)
         message?.let {
-            Text(message, style = MaterialTheme.typography.bodyLarge)
+            Text(it, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
@@ -378,6 +465,14 @@ fun CountryRow(
                     color = secondaryTextColor
                 )
             }
+
+            // Trailing chevron to indicate clickability
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "View details",
+                tint = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.6f) else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp)
+            )
         }
         HorizontalDivider()
     }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/ClimateTraceScreen.kt
@@ -1,8 +1,5 @@
 package dev.johnoreilly.climatetrace.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -257,18 +254,12 @@ fun SearchableList(
                 )
             },
             trailingIcon = {
-                AnimatedVisibility(
-                    visible = searchQuery.value.isNotBlank(),
-                    enter = fadeIn(),
-                    exit = fadeOut()
-                ) {
-                    IconButton(onClick = { onClearSearch() }) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            tint = MaterialTheme.colorScheme.onSurface,
-                            contentDescription = "clear_search"
-                        )
-                    }
+                IconButton(onClick = { onClearSearch() }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        tint = MaterialTheme.colorScheme.onSurface,
+                        contentDescription = "close_search"
+                    )
                 }
             },
             content = {
@@ -287,8 +278,10 @@ fun SearchableList(
                     }
                 }
             },
-            active = true,
-            onActiveChange = { onClearSearch() },
+            active = isSearching,
+            onActiveChange = { isActive ->
+                if (!isActive) onClearSearch()
+            },
             colors = SearchBarDefaults.colors(containerColor = MaterialTheme.colorScheme.background),
         )
     } else {

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryAssetEmissionsInfoTreeMapChart.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryAssetEmissionsInfoTreeMapChart.kt
@@ -62,6 +62,7 @@ fun CountryAssetEmissionsInfoTreeMapChart(
                     LeafItem(
                         item = export,
                         dimmed = selectedSector != null && selectedSector != export.name,
+                        isSelected = selectedSector == export.name,
                         onClick = { toggle(export.name) }
                     )
                 } else if (export is ChartNode.Section) {
@@ -151,12 +152,16 @@ fun LeafItem(
     item: ChartNode.Leaf,
     modifier: Modifier = Modifier,
     dimmed: Boolean = false,
+    isSelected: Boolean = false,
     onClick: (ChartNode.Leaf) -> Unit,
 ) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = modifier
-            .border(0.5.dp, Color.White)
+            .border(
+                width = if (isSelected) 3.dp else 0.5.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.onSurface else Color.White,
+            )
             .background(item.color.copy(alpha = if (dimmed) 0.3f else 1f))
             .clickable { onClick(item) }
             .padding(4.dp),

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryInfoDetailedView.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/CountryInfoDetailedView.kt
@@ -23,7 +23,10 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -79,13 +82,48 @@ fun CountryInfoDetailedView(
         }
         is CountryDetailsUIState.Loading -> {
             Column(
-                modifier = Modifier.fillMaxSize()
-                    .wrapContentSize(Alignment.Center)
+                modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 CircularProgressIndicator()
+                Text(
+                    text = "Loading emissions data…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
-        is CountryDetailsUIState.Error -> { Text("Error") }
+        is CountryDetailsUIState.Error -> {
+            Column(
+                modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center).padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ErrorOutline,
+                    contentDescription = "Error",
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(48.dp)
+                )
+                Text(
+                    text = "Unable to Load Details",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+                Text(
+                    text = viewState.message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.75f),
+                    textAlign = TextAlign.Center
+                )
+                Button(onClick = { onYearSelected("2025") }) {
+                    Icon(Icons.Default.Refresh, contentDescription = "Retry", modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Retry")
+                }
+            }
+        }
         is CountryDetailsUIState.Success -> {
             CountryInfoDetailedViewSuccess(viewState, perCapitaRank, onYearSelected)
         }
@@ -460,7 +498,7 @@ internal fun KeyFiguresRow(
             secondary = perCapitaSecondary,
             modifier = Modifier.weight(1f)
         )
-        StatCard(label = "Share", value = share, modifier = Modifier.weight(1f))
+        StatCard(label = "Global Share", value = share, modifier = Modifier.weight(1f))
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/RankingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/ui/RankingsScreen.kt
@@ -16,8 +16,14 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -65,12 +71,13 @@ class RankingsScreen : Screen {
             Column(Modifier.padding(paddingValues).fillMaxSize()) {
                 when (val s = state) {
                     is CountryListUIState.Loading -> {
-                        Column(modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center)) {
+                        Column(modifier = Modifier.fillMaxSize().wrapContentSize(Alignment.Center), verticalArrangement = Arrangement.spacedBy(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
                             CircularProgressIndicator()
+                            Text("Loading rankings…", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
                     is CountryListUIState.Error -> {
-                        Text("Error: ${s.message}", modifier = Modifier.padding(16.dp))
+                        ErrorState(message = s.message, onRetry = { viewModel.refresh() })
                     }
                     is CountryListUIState.Success -> {
                         RankingsContent(s)
@@ -184,6 +191,15 @@ private fun RankingRow(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.primary
             )
+            if (country != null) {
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = "View details",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
         }
         HorizontalDivider()
     }

--- a/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/CountryListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/johnoreilly/climatetrace/viewmodel/CountryListViewModel.kt
@@ -34,7 +34,16 @@ open class CountryListViewModel : ViewModel(), KoinComponent {
 
 
     init {
+        loadCountryData()
+    }
+
+    fun refresh() {
+        loadCountryData()
+    }
+
+    private fun loadCountryData() {
         viewModelScope.coroutineScope.launch {
+            _viewState.value = CountryListUIState.Loading
             try {
                 val countries = climateTraceRepository.fetchCountries().sortedBy { it.name }
                 val rankingsResponse = climateTraceRepository.fetchRankings("2025")


### PR DESCRIPTION
## Summary

UX improvements across the app based on recommended changes #1–#4, plus bonus polish that naturally fit during the same pass.

## Changes

### High Impact

**1. Error states with real messages**
- Replaced bare `Text("Error")` with proper error state composables showing an error icon, descriptive title, the actual error message, and a "Retry" button
- Applied to: ClimateTraceScreen, CountryInfoDetailedView, RankingsScreen

**2. Loading states with context**
- Added contextual loading messages alongside progress indicators
- "Loading global emissions data…", "Loading rankings…", "Loading emissions data…"

**3. Toggleable search bar**
- Search bar is now collapsed by default; tapping it expands the full search experience
- Sort chips (Name/Rank) moved **above** the search bar so they're always visible
- Clear button appears when there's active search text

**4. Refresh support**
- Extracted data loading into `loadCountryData()` in CountryListViewModel
- Added `refresh()` method so error states can trigger a retry

### Medium Impact (Bonus)

**5. Agent welcome screen**
- When the chat is empty, shows a welcome card with 4 clickable suggested prompts
- Prompts auto-fill and send the query on tap

**6. "Global Share" label**
- Renamed ambiguous "Share" stat card to "Global Share" for clarity

**7. Clickable row indicators**
- Added trailing `KeyboardArrowRight` chevron to country rows and ranking rows for consistent clickability

**8. Treemap selection feedback**
- Selected sector tiles now display a prominent 3dp border (vs 0.5dp default) for clear visual feedback

## Verification

- `composeApp:compileKotlinJvm` builds successfully with no errors